### PR TITLE
replaced molecule with fragment in some places

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,25 @@ Alchemist is a typst package to draw skeletal formulae. It is based on the [chem
 <!--EXAMPLE(links)-->
 ````typ
 #skeletize({
-  molecule(name: "A", "A")
+  fragment(name: "A", "A")
   single()
-  molecule("B")
+  fragment("B")
   branch({
     single(angle: 1)
-    molecule(
+    fragment(
       "W",
       links: (
         "A": double(stroke: red),
       ),
     )
     single()
-    molecule(name: "X", "X")
+    fragment(name: "X", "X")
   })
   branch({
     single(angle: -1)
-    molecule("Y")
+    fragment("Y")
     single()
-    molecule(
+    fragment(
       name: "Z",
       "Z",
       links: (
@@ -36,7 +36,7 @@ Alchemist is a typst package to draw skeletal formulae. It is based on the [chem
     )
   })
   single()
-  molecule(
+  fragment(
     "C",
     links: (
       "X": cram-filled-left(fill: blue),
@@ -55,7 +55,7 @@ Alchemist uses cetz to draw the molecules. This means that you can draw cetz sha
   import cetz.draw: *
   double(absolute: 30deg, name: "l1")
   single(absolute: -30deg, name: "l2")
-  molecule("X", name: "X")
+  fragment("X", name: "X")
   hobby(
     "l1.50%",
     ("l1.start", 0.5, 90deg, "l1.end"),

--- a/lib.typ
+++ b/lib.typ
@@ -50,7 +50,7 @@
   } else if mol.func() == math.equation {
     split-equation(mol, equation: true)
   } else {
-    panic("Invalid molecule content")
+    panic("Invalid fragment content")
   }
 
   if type(lewis) != array {
@@ -59,7 +59,7 @@
 
   (
     (
-      type: "molecule",
+      type: "fragment",
       name: name,
       atoms: atoms,
       links: links,
@@ -69,6 +69,7 @@
     ),
   )
 }
+#let fragment(name: none, links: (:), lewis: (), vertical: false, mol) = molecule(name: name, links: links, lewis: lewis, vertical: vertical, mol)
 
 /// === Hooks
 /// Create a hook in the molecule. It allows to connect links to the place where the hook is.

--- a/src/drawer.typ
+++ b/src/drawer.typ
@@ -41,7 +41,7 @@
       panic("Molecule " + to-name + " does not exist")
     }
     let to-hook = ctx.hooks.at(to-name)
-    if to-hook.type == "molecule" {
+    if to-hook.type == "fragment" {
       ctx.links.push((
         type: "link",
         name: link.at("name", default: "link" + str(ctx.link-id)),
@@ -103,7 +103,7 @@
 			cetz-drawing.push(element)
 		} else if "type" not in element {
 			panic("Element " + str(element) + " has no type")
-		} else if element.type == "molecule" {
+		} else if element.type == "fragment" {
 			(ctx, drawing) = molecule.draw-molecule(element, ctx)
 		} else if element.type == "link" {
 			(ctx, drawing) = link.draw-link(element, ctx)

--- a/src/drawer/cycle.typ
+++ b/src/drawer/cycle.typ
@@ -122,7 +122,7 @@
     }
   }
   let first-molecule = none
-  if ctx.last-anchor.type == "molecule" {
+  if ctx.last-anchor.type == "fragment" {
     first-molecule = ctx.last-anchor.name
     if first-molecule not in ctx.hooks {
       ctx.hooks.insert(first-molecule, ctx.last-anchor)

--- a/src/drawer/link.typ
+++ b/src/drawer/link.typ
@@ -28,7 +28,7 @@
   let from-pos = if ctx.last-anchor.type == "coord" {
     init-point = true
     ctx.last-anchor.anchor
-  } else if ctx.last-anchor.type == "molecule" {
+  } else if ctx.last-anchor.type == "fragment" {
     from-connection = link-molecule-index(
       link-angle,
       false,

--- a/src/drawer/molecule.typ
+++ b/src/drawer/molecule.typ
@@ -67,11 +67,11 @@
   let name = mol.name
   if name != none {
     if name in ctx.hooks {
-      panic("Molecule with name " + name + " already exists")
+      panic("Molecule fragment with name " + name + " already exists")
     }
     ctx.hooks.insert(name, mol)
   } else {
-    name = "molecule" + str(ctx.group-id)
+    name = "fragment" + str(ctx.group-id)
   }
   let (group-anchor, side, coord) = if ctx.last-anchor.type == "coord" {
     ("west", true, ctx.last-anchor.anchor)
@@ -88,11 +88,11 @@
     ctx.last-anchor.to-name = name
     (group-anchor, false, ctx.last-anchor.name + "-end-anchor")
   } else {
-    panic("A molecule must be linked to a coord or a link")
+    panic("A molecule fragment must be linked to a coord or a link")
   }
   ctx = context_.set-last-anchor(
     ctx,
-    (type: "molecule", name: name, count: mol.at("count"), vertical: mol.vertical),
+    (type: "fragment", name: name, count: mol.at("count"), vertical: mol.vertical),
   )
   ctx.group-id += 1
   (
@@ -122,7 +122,7 @@
 
 #let draw-molecule(element, ctx) = {
 	if ctx.first-branch {
-		panic("A molecule can not be the first element in a cycle")
+		panic("A molecule fragment can not be the first element in a cycle")
 	}
 	let (ctx, drawing) = draw-molecule-elements(element, ctx)
 	if element.links.len() != 0 {

--- a/src/drawer/parenthesis.typ
+++ b/src/drawer/parenthesis.typ
@@ -10,10 +10,10 @@
 }
 
 #let left-parenthesis-anchor(parenthesis, ctx) = {
-	let anchor = if parenthesis.body.at(0).type == "molecule" {
+	let anchor = if parenthesis.body.at(0).type == "fragment" {
     let name = parenthesis.body.at(0).name
     if name == none {
-      name = "molecule" + str(ctx.group-id)
+      name = "fragment" + str(ctx.group-id)
     }
     ctx.group-id += 1
     parenthesis.body.at(0).name = name
@@ -24,7 +24,7 @@
     parenthesis.body.at(0).name = name
     (name: name, anchor: 50%)
   } else {
-    panic("The first element of a parenthesis must be a molecule or a link")
+    panic("The first element of a parenthesis must be a molecule fragment or a link")
   }
 	(ctx, parenthesis, anchor)
 }
@@ -39,8 +39,8 @@
 		}
 	} else {
 		right-type = parenthesis.body.at(-1).type
-		if right-type == "molecule" {
-			right-name = "molecule" + str(ctx.group-id)
+		if right-type == "fragment" {
+			right-name = "fragment" + str(ctx.group-id)
 			ctx.group-id += 1
 			parenthesis.body.at(-1).name = right-name
 		} else if right-type == "link" {
@@ -50,12 +50,12 @@
 		}
  	}
 
-	let anchor = if right-type == "molecule" {
+	let anchor = if right-type == "fragment" {
 		(name: right-name, anchor: "east")
 	} else if right-type == "link" {
 		(name: right-name, anchor: 50%)
 	} else {
-		panic("The last element of a parenthesis must be a molecule or a link but got " + right-type)
+		panic("The last element of a parenthesis must be a molecule fragment or a link but got " + right-type)
 	}
 	(ctx, parenthesis, anchor)
 }

--- a/src/elements/molecule.typ
+++ b/src/elements/molecule.typ
@@ -19,19 +19,19 @@
         result.push(m)
       } else if str.match(text, regex("^[0-9]+$")) != none {
         if last-number {
-          panic("Consecutive numbers in molecule")
+          panic("Consecutive numbers in molecule fragment")
         }
         last-number = true
         result.push(m)
       } else {
-        panic("Invalid molecule content")
+        panic("Invalid molecule fragment content")
       }
     } else if m.func() == math.attach or m.func() == math.lr {
       result.push(m)
     } else if m == [ ] {
       continue
     } else {
-      panic("Invalid molecule content")
+      panic("Invalid molecule fragment content")
     }
     if last-number-hold {
       result.at(-2) = result.at(-2) + result.at(-1)

--- a/tests/README-graphic1/test.typ
+++ b/tests/README-graphic1/test.typ
@@ -3,19 +3,19 @@
 #set page(width: auto, height: auto, margin: 0.5em)
 
 #skeletize({
-  molecule(name: "A", "A")
+  fragment(name: "A", "A")
   single()
-  molecule("B")
+  fragment("B")
   branch({
     single(angle: 1)
-    molecule(
+    fragment(
       "W",
       links: (
         "A": double(stroke: red),
       ),
     )
     single()
-    molecule(name: "X", "X")
+    fragment(name: "X", "X")
   })
   branch({
     single(angle: -1)
@@ -30,7 +30,7 @@
     )
   })
   single()
-  molecule(
+  fragment(
     "C",
     links: (
       "X": cram-filled-left(fill: blue),


### PR DESCRIPTION
Changes:
- Added fragment method (forwards to molecule method)
- Updated error messages and panics to use more clear naming
- changed element.type to "fragment" instead of "molecule"
- changed automatically added name prefixes to fragment instead of molecule

I checked that our tests pass, but honestly our testing suit is not very extensive as of right now, so that should go into our Todos I think